### PR TITLE
Update x_ui middleware for 3x-ui v3 API compatibility

### DIFF
--- a/src/middleware/x_ui.py
+++ b/src/middleware/x_ui.py
@@ -331,7 +331,7 @@ class MHSANAEI:
                 "totalGB": data_limit,
                 "expiryTime": expire_time,
                 "enable": enable,
-                "tgId": "",
+                "tgId": 0,
                 "subId": "",
             })
 
@@ -382,7 +382,7 @@ class MHSANAEI:
             "totalGB": data_limit,
             "expiryTime": expire_time,
             "enable": enable,
-            "tgId": "",
+            "tgId": 0,
             "subId": "",
         }
         clients = [client]

--- a/src/middleware/x_ui.py
+++ b/src/middleware/x_ui.py
@@ -411,6 +411,8 @@ class MHSANAEI:
 
             url = f"{self._base_api_url}/inbounds/get/{inbound_id}"
 
+            logger.info(f"Calling URL: {url}")
+
             inbound_stat = requests.get(
                 url,
                 cookies=self._login_cookies,
@@ -422,6 +424,10 @@ class MHSANAEI:
                 f"Status code: {inbound_stat.status_code} for Inbound {inbound_id}"
             )
             logger.info(f"Response text for Inbound {inbound_id}: {inbound_stat.text[:500]}")
+
+            if inbound_stat.status_code != 200:
+                logger.warn(f"Non-200 response ({inbound_stat.status_code}) for inbound {inbound_id}")
+                return None
 
             data = inbound_stat.json()
 

--- a/src/middleware/x_ui.py
+++ b/src/middleware/x_ui.py
@@ -96,7 +96,7 @@ class MHSANAEI:
         return None
 
     def _post_headers(self):
-        headers = self._post_headers()
+        headers = {"Content-type": "application/json", "Accept": "text/plain"}
         if self._csrf_token:
             headers["X-CSRF-Token"] = self._csrf_token
         return headers

--- a/src/middleware/x_ui.py
+++ b/src/middleware/x_ui.py
@@ -57,7 +57,7 @@ class MHSANAEI:
             )
             if csrf_resp.status_code == 200:
                 csrf_token = csrf_resp.json().get("obj")
-                logger.info(f"CSRF token fetched: {bool(csrf_token)}")
+                logger.debug(f"Pre-login CSRF token fetched: {bool(csrf_token)}")
         except Exception as e:
             logger.warn(f"Could not fetch CSRF token: {e}")
 
@@ -67,7 +67,7 @@ class MHSANAEI:
         if csrf_token:
             headers["X-CSRF-Token"] = csrf_token
 
-        logger.info("Try login with url: " + login_url)
+        logger.debug("Try login with url: " + login_url)
         req = session.post(
             login_url,
             data=payload,
@@ -75,7 +75,10 @@ class MHSANAEI:
             verify=False,
             timeout=config.X_UI_REQUEST_TIMEOUT,
         )
-        logger.info(f"Login status: {req.status_code}, cookies: {dict(session.cookies)}, response: {req.text[:200]}")
+        if req.status_code == 200:
+            logger.info(f"Login successful for host {self._host.name}")
+        else:
+            logger.warn(f"Login failed for host {self._host.name}: status {req.status_code}")
         return session.cookies
 
     def _fetch_csrf_token(self):
@@ -89,7 +92,7 @@ class MHSANAEI:
             )
             if resp.status_code == 200:
                 token = resp.json().get("obj")
-                logger.info(f"Post-login CSRF token fetched: {bool(token)}")
+                logger.debug(f"Post-login CSRF token fetched: {bool(token)}")
                 return token
         except Exception as e:
             logger.warn(f"Could not fetch post-login CSRF token: {e}")
@@ -152,7 +155,7 @@ class MHSANAEI:
 
         url = f"{self._base_api_url}/clients/resetTraffic/{email}"
 
-        logger.info(f"Final url for reset client traffic is: {url}")
+        logger.debug(f"Final url for reset client traffic is: {url}")
 
         try:
             response = requests.post(
@@ -163,8 +166,8 @@ class MHSANAEI:
                 timeout=config.X_UI_REQUEST_TIMEOUT,
             )
             data = response.json()
-            logger.info(f"reset_client_traffic response code: {response.status_code}")
-            logger.info(f"reset_client_traffic response text: {response.text}")
+            logger.debug(f"Response code: {response.status_code}")
+            logger.debug(f"Response text: {response.text}")
 
             if response.status_code == 200 and data["success"] == True:
                 return True
@@ -179,7 +182,7 @@ class MHSANAEI:
 
         url = f"{self._base_api_url}/clients/resetAllTraffics"
 
-        logger.info(f"Final url for reset client traffic is: {url}")
+        logger.debug(f"Final url for reset clients traffic is: {url}")
 
         try:
             response = requests.post(
@@ -234,8 +237,8 @@ class MHSANAEI:
                 timeout=config.X_UI_REQUEST_TIMEOUT,
             )
             data = response.json()
-            logger.info(f"Response code: {response.status_code}")
-            logger.info(f"Response text: {response.text}")
+            logger.debug(f"Response code: {response.status_code}")
+            logger.debug(f"Response text: {response.text}")
 
             if response.status_code == 200 and data["success"] == True:
                 return True
@@ -262,7 +265,7 @@ class MHSANAEI:
 
             url = f"{self._base_api_url}/clients/add"
 
-            logger.info(f"Final url for add client is: {url}")
+            logger.debug(f"Final url for add client is: {url}")
 
             payload_add_client = json.dumps({
                 "client": {
@@ -280,8 +283,6 @@ class MHSANAEI:
                 "inboundIds": [inbound_id],
             })
 
-            logger.info(f"Final payload to add client is: {payload_add_client}")
-
             response = requests.post(
                 url,
                 cookies=self._login_cookies,
@@ -291,14 +292,14 @@ class MHSANAEI:
                 timeout=config.X_UI_REQUEST_TIMEOUT,
             )
 
-            logger.info(f"add_client response code: {response.status_code}")
-            logger.info(f"add_client response text: {response.text[:500]}")
-
             data = response.json()
+
+            logger.debug(f"add_client response code: {response.status_code}")
 
             if response.status_code == 200 and data["success"] == True:
                 return True
             else:
+                logger.warn(f"add_client failed: {response.status_code} {response.text[:200]}")
                 return False
         except Exception as error:
             logger.warn(f"add_client error: {error}")
@@ -335,8 +336,6 @@ class MHSANAEI:
                 "subId": "",
             })
 
-            logger.debug(f"Final payload to update is: {payload_update_client}")
-
             response = requests.post(
                 url,
                 cookies=self._login_cookies,
@@ -348,11 +347,11 @@ class MHSANAEI:
             data = response.json()
 
             logger.debug(f"Response code: {response.status_code}")
-            logger.debug(f"Response text: {response.text}")
 
             if response.status_code == 200 and data["success"] is True:
                 return True
             else:
+                logger.warn(f"update_client failed: {response.status_code} {response.text[:200]}")
                 return False
         except Exception as error:
             logger.warn(error)
@@ -397,7 +396,7 @@ class MHSANAEI:
         inbound_id: int,
     ):
         try:
-            logger.info(f"Get client stats from {self._host.name} inbound {inbound_id}")
+            logger.debug(f"Get client stats from {self._host.name} inbound {inbound_id}")
 
             url = f"{self._base_api_url}/inbounds/get/{inbound_id}"
 
@@ -411,9 +410,7 @@ class MHSANAEI:
             data = response.json()
 
             if data.get("obj") is not None:
-                stats = data["obj"].get("clientStats")
-                logger.info(f"clientStats for inbound {inbound_id}: {str(stats)[:500]}")
-                return stats
+                return data["obj"].get("clientStats")
 
             return None
         except Exception as error:
@@ -454,11 +451,9 @@ class MHSANAEI:
         inbound_id: int,
     ):
         try:
-            logger.info(f"Get clients from {self._host.name} inbound {inbound_id}")
+            logger.debug(f"Get clients from {self._host.name} inbound {inbound_id}")
 
             url = f"{self._base_api_url}/inbounds/get/{inbound_id}"
-
-            logger.info(f"Calling URL: {url}")
 
             inbound_stat = requests.get(
                 url,
@@ -467,10 +462,9 @@ class MHSANAEI:
                 timeout=config.X_UI_REQUEST_TIMEOUT,
             )
 
-            logger.info(
+            logger.debug(
                 f"Status code: {inbound_stat.status_code} for Inbound {inbound_id}"
             )
-            logger.info(f"Response text for Inbound {inbound_id}: {inbound_stat.text[:500]}")
 
             if inbound_stat.status_code != 200:
                 logger.warn(f"Non-200 response ({inbound_stat.status_code}) for inbound {inbound_id}")

--- a/src/middleware/x_ui.py
+++ b/src/middleware/x_ui.py
@@ -262,7 +262,7 @@ class MHSANAEI:
 
             url = f"{self._base_api_url}/clients/add"
 
-            logger.debug(f"Final url for add client is: {url}")
+            logger.info(f"Final url for add client is: {url}")
 
             payload_add_client = json.dumps({
                 "client": {
@@ -280,7 +280,7 @@ class MHSANAEI:
                 "inboundIds": [inbound_id],
             })
 
-            logger.debug(f"Final payload to add client is: {payload_add_client}")
+            logger.info(f"Final payload to add client is: {payload_add_client}")
 
             response = requests.post(
                 url,
@@ -290,17 +290,18 @@ class MHSANAEI:
                 headers=headers,
                 timeout=config.X_UI_REQUEST_TIMEOUT,
             )
-            data = response.json()
 
-            logger.debug(f"Response code: {response.status_code}")
-            logger.debug(f"Response text: {response.text}")
+            logger.info(f"add_client response code: {response.status_code}")
+            logger.info(f"add_client response text: {response.text[:500]}")
+
+            data = response.json()
 
             if response.status_code == 200 and data["success"] == True:
                 return True
             else:
                 return False
         except Exception as error:
-            logger.warn(error)
+            logger.warn(f"add_client error: {error}")
             return False
 
     def update_client(

--- a/src/middleware/x_ui.py
+++ b/src/middleware/x_ui.py
@@ -50,7 +50,7 @@ class MHSANAEI:
         req = requests.request(
             "POST",
             login_url,
-            data=payload,
+            json=payload,
             verify=False,
             timeout=config.X_UI_REQUEST_TIMEOUT,
         )
@@ -78,7 +78,7 @@ class MHSANAEI:
 
     def get_client_stat(self, email: str):
         try:
-            url = f"{self._base_api_url}/inbounds/getClientTraffics/{email}"
+            url = f"{self._base_api_url}/clients/traffic/{email}"
             client_stat = requests.get(
                 url,
                 cookies=self._login_cookies,
@@ -106,7 +106,7 @@ class MHSANAEI:
     def reset_client_traffic(self, inbound_id: int, email: str):
         headers = {"Content-type": "application/json", "Accept": "text/plain"}
 
-        url = f"{self._base_api_url}/inbounds/{inbound_id}/resetClientTraffic/{email}"
+        url = f"{self._base_api_url}/clients/resetTraffic/{email}"
 
         logger.debug(f"Final url for reset client traffic is: {url}")
 
@@ -133,7 +133,7 @@ class MHSANAEI:
     def reset_clients_traffic(self, inbound_id: int):
         headers = {"Content-type": "application/json", "Accept": "text/plain"}
 
-        url = f"{self._base_api_url}/inbounds/resetAllClientTraffics/{inbound_id}"
+        url = f"{self._base_api_url}/clients/resetAllTraffics"
 
         logger.info(f"Final url for reset client traffic is: {url}")
 
@@ -159,11 +159,26 @@ class MHSANAEI:
             return False
 
     def delete_client(self, inbound_id: int, uuid: str):
-
         try:
             headers = {"Content-type": "application/json", "Accept": "text/plain"}
 
-            url = f"{self._base_api_url}/inbounds/{inbound_id}/delClient/{uuid}"
+            # New API deletes by email; look up the email from the inbound's client list.
+            clients = self.get_inbound_clients(inbound_id)
+            if not clients:
+                logger.warn(f"No clients found in inbound {inbound_id} for uuid {uuid}")
+                return False
+
+            client_email = None
+            for client in clients:
+                if client.get("id") == uuid:
+                    client_email = client.get("email")
+                    break
+
+            if client_email is None:
+                logger.warn(f"Client with uuid {uuid} not found in inbound {inbound_id}")
+                return False
+
+            url = f"{self._base_api_url}/clients/del/{client_email}"
 
             logger.debug(f"Final url for delete client is: {url}")
 
@@ -201,20 +216,25 @@ class MHSANAEI:
         try:
             headers = {"Content-type": "application/json", "Accept": "text/plain"}
 
-            url = f"{self._base_api_url}/inbounds/addClient"
+            url = f"{self._base_api_url}/clients/add"
 
-            logger.debug(f"Final url fro add client is: {url}")
+            logger.debug(f"Final url for add client is: {url}")
 
-            payload_add_client = MHSANAEI.get_client_payload(
-                data_limit,
-                email,
-                enable,
-                expire_time,
-                inbound_id,
-                uuid,
-                ip_limit=ip_limit,
-                flow=flow,
-            )
+            payload_add_client = json.dumps({
+                "client": {
+                    "id": uuid,
+                    "flow": flow,
+                    "alterId": 0,
+                    "email": email,
+                    "limitIp": ip_limit,
+                    "totalGB": data_limit,
+                    "expiryTime": expire_time,
+                    "enable": enable,
+                    "tgId": "",
+                    "subId": "",
+                },
+                "inboundIds": [inbound_id],
+            })
 
             logger.debug(f"Final payload to add client is: {payload_add_client}")
 
@@ -253,27 +273,29 @@ class MHSANAEI:
         try:
             headers = {"Content-type": "application/json", "Accept": "text/plain"}
 
-            url = f"{self._base_api_url}/inbounds/updateClient/{uuid}"
+            url = f"{self._base_api_url}/clients/update/{email}"
 
             logger.debug(f"Final url for update client is: {url}")
 
-            payload_add_client = MHSANAEI.get_client_payload(
-                data_limit,
-                email,
-                enable,
-                expire_time,
-                inbound_id,
-                uuid,
-                ip_limit=ip_limit,
-                flow=flow,
-            )
+            payload_update_client = json.dumps({
+                "id": uuid,
+                "flow": flow,
+                "alterId": 0,
+                "email": email,
+                "limitIp": ip_limit,
+                "totalGB": data_limit,
+                "expiryTime": expire_time,
+                "enable": enable,
+                "tgId": "",
+                "subId": "",
+            })
 
-            logger.debug(f"Final payload to update is: {payload_add_client}")
+            logger.debug(f"Final payload to update is: {payload_update_client}")
 
             response = requests.post(
                 url,
                 cookies=self._login_cookies,
-                data=payload_add_client,
+                data=payload_update_client,
                 verify=False,
                 headers=headers,
                 timeout=config.X_UI_REQUEST_TIMEOUT,
@@ -332,7 +354,7 @@ class MHSANAEI:
         try:
             logger.debug(f"Get clients from {self._host.name} inbound {inbound_id}")
 
-            url = f"{self._base_api_url}/inbounds/list"
+            url = f"{self._base_api_url}/inbounds/get/{inbound_id}"
 
             response = requests.get(
                 url,
@@ -343,12 +365,8 @@ class MHSANAEI:
 
             data = response.json()
 
-            remote_inbound_list = data["obj"]
-
-            if remote_inbound_list is not None:
-                for remote_inbound in remote_inbound_list:
-                    if int(remote_inbound["id"]) == inbound_id:
-                        return remote_inbound["clientStats"]
+            if data.get("obj") is not None:
+                return data["obj"].get("clientStats")
 
             return None
         except Exception as error:
@@ -409,7 +427,8 @@ class MHSANAEI:
             settings = data["obj"]["settings"]
 
             if settings:
-                setting_obj = json.loads(settings)
+                # New API returns settings as a nested object; legacy versions return a JSON string.
+                setting_obj = json.loads(settings) if isinstance(settings, str) else settings
                 clients = setting_obj["clients"]
                 return clients
             else:

--- a/src/middleware/x_ui.py
+++ b/src/middleware/x_ui.py
@@ -44,18 +44,38 @@ class MHSANAEI:
 
     def _get_login_cookie(self):
         base_login_url = self._base_api_url.replace("/panel/api", "")
+
+        # 3x-ui v3 requires a CSRF token on all unsafe (POST) requests.
+        # Use a session so the pre-login session cookie is carried into the login call.
+        session = requests.Session()
+        csrf_token = None
+        try:
+            csrf_url = base_login_url + "/csrf-token"
+            csrf_resp = session.get(
+                csrf_url, verify=False, timeout=config.X_UI_REQUEST_TIMEOUT
+            )
+            if csrf_resp.status_code == 200:
+                csrf_token = csrf_resp.json().get("obj")
+                logger.info(f"CSRF token fetched: {bool(csrf_token)}")
+        except Exception as e:
+            logger.warn(f"Could not fetch CSRF token: {e}")
+
         login_url = base_login_url + "/login"
         payload = {"username": self._host.username, "password": self._host.password}
+        headers = {}
+        if csrf_token:
+            headers["X-CSRF-Token"] = csrf_token
+
         logger.info("Try login with url: " + login_url)
-        req = requests.request(
-            "POST",
+        req = session.post(
             login_url,
             data=payload,
+            headers=headers,
             verify=False,
             timeout=config.X_UI_REQUEST_TIMEOUT,
         )
-        logger.info(f"Login status: {req.status_code}, cookies: {dict(req.cookies)}, response: {req.text[:200]}")
-        return req.cookies
+        logger.info(f"Login status: {req.status_code}, cookies: {dict(session.cookies)}, response: {req.text[:200]}")
+        return session.cookies
 
     @staticmethod
     def get_account_email_prefix(inbound_key: int, email: str):

--- a/src/middleware/x_ui.py
+++ b/src/middleware/x_ui.py
@@ -27,6 +27,7 @@ class MHSANAEI:
             api_path=host.api_path, ssl=self._host.master
         )
         self._login_cookies = self._get_login_cookie()
+        self._csrf_token = self._fetch_csrf_token()
 
     def _generate_base_url(self, ssl: bool = False, api_path: str = ""):
         address = self._host.ip if self._host.domain is None else self._host.domain
@@ -77,6 +78,29 @@ class MHSANAEI:
         logger.info(f"Login status: {req.status_code}, cookies: {dict(session.cookies)}, response: {req.text[:200]}")
         return session.cookies
 
+    def _fetch_csrf_token(self):
+        base_url = self._base_api_url.replace("/panel/api", "")
+        try:
+            resp = requests.get(
+                base_url + "/csrf-token",
+                cookies=self._login_cookies,
+                verify=False,
+                timeout=config.X_UI_REQUEST_TIMEOUT,
+            )
+            if resp.status_code == 200:
+                token = resp.json().get("obj")
+                logger.info(f"Post-login CSRF token fetched: {bool(token)}")
+                return token
+        except Exception as e:
+            logger.warn(f"Could not fetch post-login CSRF token: {e}")
+        return None
+
+    def _post_headers(self):
+        headers = self._post_headers()
+        if self._csrf_token:
+            headers["X-CSRF-Token"] = self._csrf_token
+        return headers
+
     @staticmethod
     def get_account_email_prefix(inbound_key: int, email: str):
         return "%s_%s" % (inbound_key, email)
@@ -124,7 +148,7 @@ class MHSANAEI:
             return None
 
     def reset_client_traffic(self, inbound_id: int, email: str):
-        headers = {"Content-type": "application/json", "Accept": "text/plain"}
+        headers = self._post_headers()
 
         url = f"{self._base_api_url}/clients/resetTraffic/{email}"
 
@@ -151,7 +175,7 @@ class MHSANAEI:
             return False
 
     def reset_clients_traffic(self, inbound_id: int):
-        headers = {"Content-type": "application/json", "Accept": "text/plain"}
+        headers = self._post_headers()
 
         url = f"{self._base_api_url}/clients/resetAllTraffics"
 
@@ -180,7 +204,7 @@ class MHSANAEI:
 
     def delete_client(self, inbound_id: int, uuid: str):
         try:
-            headers = {"Content-type": "application/json", "Accept": "text/plain"}
+            headers = self._post_headers()
 
             # New API deletes by email; look up the email from the inbound's client list.
             clients = self.get_inbound_clients(inbound_id)
@@ -234,7 +258,7 @@ class MHSANAEI:
     ):
 
         try:
-            headers = {"Content-type": "application/json", "Accept": "text/plain"}
+            headers = self._post_headers()
 
             url = f"{self._base_api_url}/clients/add"
 
@@ -291,7 +315,7 @@ class MHSANAEI:
         enable: bool = True,
     ):
         try:
-            headers = {"Content-type": "application/json", "Accept": "text/plain"}
+            headers = self._post_headers()
 
             url = f"{self._base_api_url}/clients/update/{email}"
 

--- a/src/middleware/x_ui.py
+++ b/src/middleware/x_ui.py
@@ -274,7 +274,7 @@ class MHSANAEI:
                     "totalGB": data_limit,
                     "expiryTime": expire_time,
                     "enable": enable,
-                    "tgId": "",
+                    "tgId": 0,
                     "subId": "",
                 },
                 "inboundIds": [inbound_id],

--- a/src/middleware/x_ui.py
+++ b/src/middleware/x_ui.py
@@ -418,9 +418,10 @@ class MHSANAEI:
                 timeout=config.X_UI_REQUEST_TIMEOUT,
             )
 
-            logger.debug(
+            logger.info(
                 f"Status code: {inbound_stat.status_code} for Inbound {inbound_id}"
             )
+            logger.info(f"Response text for Inbound {inbound_id}: {inbound_stat.text[:500]}")
 
             data = inbound_stat.json()
 

--- a/src/middleware/x_ui.py
+++ b/src/middleware/x_ui.py
@@ -46,7 +46,7 @@ class MHSANAEI:
         base_login_url = self._base_api_url.replace("/panel/api", "")
         login_url = base_login_url + "/login"
         payload = {"username": self._host.username, "password": self._host.password}
-        logger.debug("Try login with url: " + login_url)
+        logger.info("Try login with url: " + login_url)
         req = requests.request(
             "POST",
             login_url,
@@ -54,7 +54,7 @@ class MHSANAEI:
             verify=False,
             timeout=config.X_UI_REQUEST_TIMEOUT,
         )
-        logger.debug(f"Login response: {req.text}")
+        logger.info(f"Login status: {req.status_code}, cookies: {dict(req.cookies)}, response: {req.text[:200]}")
         return req.cookies
 
     @staticmethod

--- a/src/middleware/x_ui.py
+++ b/src/middleware/x_ui.py
@@ -50,7 +50,7 @@ class MHSANAEI:
         req = requests.request(
             "POST",
             login_url,
-            json=payload,
+            data=payload,
             verify=False,
             timeout=config.X_UI_REQUEST_TIMEOUT,
         )

--- a/src/middleware/x_ui.py
+++ b/src/middleware/x_ui.py
@@ -397,7 +397,7 @@ class MHSANAEI:
         inbound_id: int,
     ):
         try:
-            logger.debug(f"Get clients from {self._host.name} inbound {inbound_id}")
+            logger.info(f"Get client stats from {self._host.name} inbound {inbound_id}")
 
             url = f"{self._base_api_url}/inbounds/get/{inbound_id}"
 
@@ -411,7 +411,9 @@ class MHSANAEI:
             data = response.json()
 
             if data.get("obj") is not None:
-                return data["obj"].get("clientStats")
+                stats = data["obj"].get("clientStats")
+                logger.info(f"clientStats for inbound {inbound_id}: {str(stats)[:500]}")
+                return stats
 
             return None
         except Exception as error:

--- a/src/middleware/x_ui.py
+++ b/src/middleware/x_ui.py
@@ -152,7 +152,7 @@ class MHSANAEI:
 
         url = f"{self._base_api_url}/clients/resetTraffic/{email}"
 
-        logger.debug(f"Final url for reset client traffic is: {url}")
+        logger.info(f"Final url for reset client traffic is: {url}")
 
         try:
             response = requests.post(
@@ -163,8 +163,8 @@ class MHSANAEI:
                 timeout=config.X_UI_REQUEST_TIMEOUT,
             )
             data = response.json()
-            logger.debug(f"Response code: {response.status_code}")
-            logger.debug(f"Response text: {response.text}")
+            logger.info(f"reset_client_traffic response code: {response.status_code}")
+            logger.info(f"reset_client_traffic response text: {response.text}")
 
             if response.status_code == 200 and data["success"] == True:
                 return True


### PR DESCRIPTION
Summary
This PR updates the x_ui middleware to support the 3x-ui v3 API, which includes significant endpoint changes, CSRF token requirements, and payload structure modifications.

Key Changes
CSRF Token Support: Added CSRF token fetching and validation for v3 API compatibility

Fetch pre-login CSRF token before authentication
Fetch post-login CSRF token after successful login
Include CSRF token in all POST request headers via _post_headers() method
API Endpoint Updates: Updated all API endpoints to match v3 naming conventions

inbounds/getClientTraffics/{email} → clients/traffic/{email}
inbounds/{id}/resetClientTraffic/{email} → clients/resetTraffic/{email}
inbounds/resetAllClientTraffics/{id} → clients/resetAllTraffics
inbounds/{id}/delClient/{uuid} → clients/del/{email}
inbounds/addClient → clients/add
inbounds/updateClient/{uuid} → clients/update/{email}
inbounds/list → inbounds/get/{id} (for client stats)
Payload Structure Changes: Refactored client payloads to match v3 API format

add_client: Wrapped payload in {"client": {...}, "inboundIds": [...]}
update_client: Simplified payload structure
Removed dependency on MHSANAEI.get_client_payload() for add/update operations
Client Deletion Logic: Enhanced delete_client() to work with email-based deletion

Look up client email from inbound's client list using UUID
Use email for deletion instead of UUID
Response Handling Improvements:

Added status code validation in get_inbound_clients()
Handle both JSON object and string formats for settings field
Improved error logging with more context
Session Management: Use persistent requests.Session() for login to maintain cookies across CSRF token fetch and login request

Logging Adjustments: Changed some info-level logs to debug level for cleaner output